### PR TITLE
Remove restartPolicy for elastalert deploy

### DIFF
--- a/1.4.0/templates/dep-elastalert.yaml
+++ b/1.4.0/templates/dep-elastalert.yaml
@@ -47,8 +47,7 @@ spec:
              sleep 2;
              export COUNT=$(kubectl get pods -l app=maya-io -n {{ .Release.Namespace }} -o json  | jq -r '.items[] | select(.status.phase == "Running" and ([ .status.conditions[] | select(.type == "Ready" and .status == "True") ] | length ) >= 1 ) | .metadata.name' | grep -w maya-io | wc -l)
              echo $COUNT
-          done    
-        restartPolicy: Never 
+          done
       containers:
       - name: elastalert
         image: registry.mayadata.io/elastalert:{{ .Values.server.release }}


### PR DESCRIPTION
Deployments only support restartPolicy = Always; so do Replication Controllers, Replica Sets, and Daemon Sets.


ref: https://github.com/kubernetes/kubernetes/issues/24725
ref: https://stackoverflow.com/questions/55169075/restartpolicy-unsupported-value-never-supported-values-always
Signed-off-by: inyee786 <intakhab.ali@mayadata.io>