### PR TITLE
Fixed configs-db(postgres) deployment yaml to accommodate a breaking postgres security fix.

### DIFF
--- a/1.7.0/templates/dep-configs-db.yaml
+++ b/1.7.0/templates/dep-configs-db.yaml
@@ -21,6 +21,8 @@ spec:
         env:
           - name: POSTGRES_DB
             value: configs
+          - name: POSTGRES_HOST_AUTH_METHOD
+            value: trust
         ports:
         - containerPort: 5432
       imagePullSecrets:


### PR DESCRIPTION
Without this, the postgres db is not able to
start in k8s with Container Optimized OS (COS).

ref: https://github.com/docker-library/postgres/issues/681